### PR TITLE
Add watchdog to reboot camera drivers

### DIFF
--- a/src/surface/rov_flir/launch/flir_launch.py
+++ b/src/surface/rov_flir/launch/flir_launch.py
@@ -19,7 +19,7 @@ def generate_launch_description() -> LaunchDescription:
 
     parameters = {
         'debug': False,
-        'acquisition_timeout': 2.0,
+        'acquisition_timeout': 0.5,
         'compute_brightness': False,
         'adjust_timestamp': True,
         'dump_node_map': False,

--- a/src/surface/rov_flir/launch/flir_launch.py
+++ b/src/surface/rov_flir/launch/flir_launch.py
@@ -2,17 +2,24 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch.launch_description import LaunchDescription
-from launch_ros.actions import Node
+from launch_ros.actions import Node, PushRosNamespace
 from launch_ros.parameter_descriptions import Parameter
+from launch.substitutions.launch_configuration import LaunchConfiguration
+from launch.conditions import IfCondition
+from launch.actions import GroupAction
 
 
 def generate_launch_description() -> LaunchDescription:
+    front_arg = LaunchConfiguration('launch_front', default=True)
+    bottom_arg = LaunchConfiguration('launch_bottom', default=True)
+    ns_arg = LaunchConfiguration('ns', default='')
 
     parameter_file = os.path.join(get_package_share_directory('rov_flir'), 'config',
                                   'blackfly_s.yaml')
 
     parameters = {
         'debug': False,
+        'acquisition_timeout': 2.0,
         'compute_brightness': False,
         'adjust_timestamp': True,
         'dump_node_map': False,
@@ -57,7 +64,8 @@ def generate_launch_description() -> LaunchDescription:
         output='screen',
         parameters=[Parameter('serial_number', '23473577'),
                     Parameter('parameter_file', parameter_file),
-                    parameters]
+                    parameters],
+        condition=IfCondition(front_arg)
     )
 
     # launches node to run bottom flir camera
@@ -70,10 +78,16 @@ def generate_launch_description() -> LaunchDescription:
         output='screen',
         parameters=[Parameter('serial_number', '23473566'),
                     Parameter('parameter_file', parameter_file),
-                    parameters]
+                    parameters],
+        condition=IfCondition(bottom_arg)
     )
 
-    return LaunchDescription([
-        front_cam,
-        bottom_cam
-    ])
+    namespace_launch = GroupAction(
+        actions=[
+            PushRosNamespace(ns_arg),
+            front_cam,
+            bottom_cam
+        ]
+    )
+
+    return LaunchDescription([namespace_launch])

--- a/src/surface/rov_flir/rov_flir/flir_watchdog.py
+++ b/src/surface/rov_flir/rov_flir/flir_watchdog.py
@@ -4,14 +4,14 @@ from rclpy.node import Node
 from subprocess import Popen
 import atexit
 
-from typing import List, Optional
+from typing import Optional
 
 WATCHDOG_RATE = 10
 NAMESPACE = "surface"
 
 
 class Watchdog():
-    def __init__(self, node: Node, args: List[str]) -> None:
+    def __init__(self, node: Node, args: list[str]) -> None:
         self.node: Node = node
         self.args = args
         self.process: Optional[Popen[bytes]] = None

--- a/src/surface/rov_flir/rov_flir/flir_watchdog.py
+++ b/src/surface/rov_flir/rov_flir/flir_watchdog.py
@@ -3,6 +3,7 @@ from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from subprocess import Popen
 import atexit
+import sys
 
 from typing import Optional
 

--- a/src/surface/rov_flir/rov_flir/flir_watchdog.py
+++ b/src/surface/rov_flir/rov_flir/flir_watchdog.py
@@ -1,0 +1,69 @@
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from subprocess import Popen
+import atexit
+
+from typing import List, Optional
+
+WATCHDOG_RATE = 10
+NAMESPACE = "surface"
+
+
+class Watchdog():
+    def __init__(self, node: Node, args: List[str]) -> None:
+        self.node: Node = node
+        self.args = args
+        self.process: Optional[Popen[bytes]] = None
+
+        self.start_process()
+
+    def start_process(self) -> None:
+        self.process = Popen(self.args)
+
+    def poll(self) -> None:
+        if self.process is not None and self.process.poll() is not None:
+            self.node.get_logger().warning("Detected camera crash, restarting...")
+            self.start_process()
+
+    def kill(self) -> None:
+        if self.process:
+            self.process.kill()
+
+
+class FlirWatchdogNode(Node):
+    def __init__(self) -> None:
+        super().__init__("flir_watchdog_node", parameter_overrides=[])
+
+        self.timer = self.create_timer(1 / WATCHDOG_RATE, self.timer_callback)
+
+        self.get_logger().info("Starting camera drivers")
+
+        self.front_watchdog = Watchdog(
+            node=self,
+            args=["ros2", "launch", "rov_flir", "flir_launch.py",
+                  "launch_bottom:=false", f"ns:={NAMESPACE}"],
+        )
+        self.bottom_watchdog = Watchdog(
+            node=self,
+            args=["ros2", "launch", "rov_flir", "flir_launch.py",
+                  "launch_front:=false", f"ns:={NAMESPACE}"],
+        )
+
+        atexit.register(self.front_watchdog.kill)
+        atexit.register(self.bottom_watchdog.kill)
+
+    def timer_callback(self) -> None:
+        self.front_watchdog.poll()
+        self.bottom_watchdog.poll()
+
+
+def main() -> None:
+    rclpy.init()
+    flir_watchdog_node = FlirWatchdogNode()
+    executor = MultiThreadedExecutor()
+    rclpy.spin(flir_watchdog_node, executor=executor)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/surface/rov_flir/setup.py
+++ b/src/surface/rov_flir/setup.py
@@ -26,5 +26,9 @@ setup(
     description='Boilerplate for calling standard flir launch file.',
     license='Apache License 2.0',
     tests_require=['pytest'],
-    entry_points={},
+    entry_points={
+        'console_scripts': [
+            'flir_watchdog = rov_flir.flir_watchdog:main',
+        ],
+    },
 )

--- a/src/surface/surface_main/launch/surface_pilot_launch.py
+++ b/src/surface/surface_main/launch/surface_pilot_launch.py
@@ -4,7 +4,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch.launch_description import LaunchDescription
 from launch.actions import GroupAction, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import PushRosNamespace, Node
 from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 
@@ -13,7 +13,7 @@ def generate_launch_description() -> LaunchDescription:
 
     gui_path: str = get_package_share_directory('gui')
     controller_path: str = get_package_share_directory('ps5_controller')
-    flir_path: str = get_package_share_directory('rov_flir')
+    # flir_path: str = get_package_share_directory('rov_flir')
 
     simulation_configuration = LaunchConfiguration('simulation', default=False)
 
@@ -36,12 +36,20 @@ def generate_launch_description() -> LaunchDescription:
     )
 
     # Launches flir
-    flir_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([
-            os.path.join(
-                flir_path, 'launch', 'flir_launch.py'
-            )
-        ]),
+    # flir_launch = IncludeLaunchDescription(
+    #     PythonLaunchDescriptionSource([
+    #         os.path.join(
+    #             flir_path, 'launch', 'flir_launch.py'
+    #         )
+    #     ]),
+    #     condition=UnlessCondition(simulation_configuration)
+    # )
+    flir_launch = Node(
+        package='rov_flir',
+        executable='flir_watchdog',
+        name='flir_watchdog',
+        emulate_tty=True,
+        output='screen',
         condition=UnlessCondition(simulation_configuration)
     )
 

--- a/src/surface/surface_main/launch/surface_pilot_launch.py
+++ b/src/surface/surface_main/launch/surface_pilot_launch.py
@@ -44,7 +44,8 @@ def generate_launch_description() -> LaunchDescription:
     #     ]),
     #     condition=UnlessCondition(simulation_configuration)
     # )
-    flir_launch = Node(
+
+    flir_watchdog = Node(
         package='rov_flir',
         executable='flir_watchdog',
         name='flir_watchdog',
@@ -58,7 +59,7 @@ def generate_launch_description() -> LaunchDescription:
             PushRosNamespace("surface"),
             gui_launch,
             controller_launch,
-            flir_launch
+            flir_watchdog
         ]
     )
 


### PR DESCRIPTION
# Pull Request

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The flir camera drivers crash when the camera disconnects (after a timeout). This adds a watchdog to run the drivers in their own thread and automatically reboot them when they crash. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #
