### PR TITLE
Reboot frozen cam drivers

### DIFF
--- a/src/surface/rov_flir/rov_flir/flir_watchdog.py
+++ b/src/surface/rov_flir/rov_flir/flir_watchdog.py
@@ -1,6 +1,9 @@
 import atexit
-import sys
+import os
+import subprocess
 from subprocess import Popen
+import re
+from signal import SIGINT
 
 import rclpy
 from rclpy.executors import MultiThreadedExecutor
@@ -11,7 +14,8 @@ NAMESPACE = "surface"
 
 
 class Watchdog():
-    def __init__(self, node: Node, args: list[str]) -> None:
+    def __init__(self, name: str, node: Node, args: list[str]) -> None:
+        self.name = name
         self.node = node
         self.args = args
         self.process: Popen[bytes]
@@ -19,12 +23,41 @@ class Watchdog():
         self.start_process()
 
     def start_process(self) -> None:
-        self.process = Popen(self.args, stdout=sys.stdout, stderr=sys.stderr)
+        self.process = Popen(self.args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        if self.process.stdout is None:
+            raise RuntimeError("Child process has not stdout")
+
+        os.set_blocking(self.process.stdout.fileno(), False)
+
+    def read_stdout(self) -> bytes:
+        if self.process.stdout is None:
+            raise RuntimeError("Child process has not stdout")
+
+        return self.process.stdout.readline()
 
     def poll(self) -> None:
         if self.process.poll() is not None:
-            self.node.get_logger().warning("Detected camera crash, restarting...")
+            self.node.get_logger().warning(f"{self.name} has crashed, restarting...")
             self.start_process()
+            return
+
+        line = self.read_stdout()
+        while line:
+            m = re.search(r"rate \[Hz] in +([\d\.]+) out", line.decode().strip())
+            if m:
+                try:
+                    rate = float(m.group(1))
+                except ValueError:
+                    continue
+
+                if rate < 60.0:
+                    # If we're receiving less than 1 fps, assume the camera has disconnected
+                    self.node.get_logger().warning(f"{self.name} frozen, killing...")
+                    self.process.send_signal(SIGINT)
+                    return
+
+            line = self.read_stdout()
 
     def kill(self) -> None:
         self.process.kill()
@@ -39,11 +72,13 @@ class FlirWatchdogNode(Node):
         self.get_logger().info("Starting camera drivers")
 
         self.front_watchdog = Watchdog(
+            name="Front cam",
             node=self,
             args=["ros2", "launch", "rov_flir", "flir_launch.py",
                   "launch_bottom:=false", f"ns:={NAMESPACE}"]
         )
         self.bottom_watchdog = Watchdog(
+            name="Bottom cam",
             node=self,
             args=["ros2", "launch", "rov_flir", "flir_launch.py",
                   "launch_front:=false", f"ns:={NAMESPACE}"]

--- a/src/surface/rov_flir/rov_flir/flir_watchdog.py
+++ b/src/surface/rov_flir/rov_flir/flir_watchdog.py
@@ -51,7 +51,7 @@ class Watchdog():
                 except ValueError:
                     continue
 
-                if rate < 60.0:
+                if rate < 1.0:
                     # If we're receiving less than 1 fps, assume the camera has disconnected
                     self.node.get_logger().warning(f"{self.name} frozen, killing...")
                     self.process.send_signal(SIGINT)

--- a/src/surface/rov_flir/rov_flir/flir_watchdog.py
+++ b/src/surface/rov_flir/rov_flir/flir_watchdog.py
@@ -11,6 +11,7 @@ from rclpy.node import Node
 
 WATCHDOG_RATE = 10
 NAMESPACE = "surface"
+MIN_FPS = 1.0
 
 
 class Watchdog():
@@ -44,14 +45,14 @@ class Watchdog():
 
         line = self.read_stdout()
         while line:
-            m = re.search(r"rate \[Hz] in +([\d\.]+) out", line.decode().strip())
-            if m:
+            match = re.search(r"rate \[Hz] in +([\d\.]+) out", line.decode().strip())
+            if match:
                 try:
-                    rate = float(m.group(1))
+                    rate = float(match.group(1))
                 except ValueError:
                     continue
 
-                if rate < 1.0:
+                if rate < MIN_FPS:
                     # If we're receiving less than 1 fps, assume the camera has disconnected
                     self.node.get_logger().warning(f"{self.name} frozen, killing...")
                     self.process.send_signal(SIGINT)


### PR DESCRIPTION
# Pull Request

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When a camera stream drops below 1 fps, restart the driver

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #
