### PR TITLE
Float schedule tweaks

### DIFF
--- a/src/float/float_transceiver/float_transceiver.ino
+++ b/src/float/float_transceiver/float_transceiver.ino
@@ -42,7 +42,7 @@ const uint32_t ASCEND_TIME = 0;  // Disable ascend times now that we're properly
 const uint32_t TX_MAX = 60000;
 const uint32_t ONE_HOUR = 360000;
 
-const uint8_t SCHEDULE_LENGTH = 11;
+const uint8_t SCHEDULE_LENGTH = 12;
 
 enum class StageType { WaitDeploying, WaitTransmitting, WaitProfiling, Suck, Pump };
 enum class OverrideState { NoOverride, Stop, Suck, Pump };
@@ -132,6 +132,9 @@ void setup() {
 
   initRadio();
   initPressureSensor();
+
+  // Start our first stage by pumping
+  pump();
 }
 
 void loop() {

--- a/src/float/float_transceiver/float_transceiver.ino
+++ b/src/float/float_transceiver/float_transceiver.ino
@@ -225,7 +225,9 @@ void loop() {
   bool pumpingHitLimitSwitch = stageIs(StageType::Pump) && !digitalRead(LIMIT_EMPTY);
   bool shouldSubmerge = isSurfaced() && submergeReceived;
 
-  if (shouldSubmerge || stageTimedOut || suckingHitLimitSwitch || pumpingHitLimitSwitch || isStartingStage) {
+  if (
+    shouldSubmerge || stageTimedOut || suckingHitLimitSwitch || pumpingHitLimitSwitch ||
+    isStartingStage) {
     serialPrintf(
       "Ending stage #%d, type: %d, start time: %l, max wait time: %l, current time: %l\n",
       currentStage, SCHEDULE[currentStage].type, stageStartTime,

--- a/src/float/float_transceiver/float_transceiver.ino
+++ b/src/float/float_transceiver/float_transceiver.ino
@@ -35,10 +35,10 @@ const uint32_t PROFILE_SEGMENT = 60000;
 
 // Schedule (all delays in ms)
 const uint32_t RELEASE_MAX = 300000;
-const uint32_t SUCK_MAX = PRESSURE_READ_INTERVAL;
-const uint32_t DESCEND_TIME = PRESSURE_READ_INTERVAL;
-const uint32_t PUMP_MAX = PRESSURE_READ_INTERVAL;
-const uint32_t ASCEND_TIME = PRESSURE_READ_INTERVAL;
+const uint32_t SUCK_MAX = PROFILE_SEGMENT;
+const uint32_t DESCEND_TIME = PROFILE_SEGMENT;
+const uint32_t PUMP_MAX = PROFILE_SEGMENT;
+const uint32_t ASCEND_TIME = 0;  // Disable ascend times now that we're properly ballasted
 const uint32_t TX_MAX = 60000;
 const uint32_t ONE_HOUR = 360000;
 
@@ -57,7 +57,10 @@ OverrideState overrideState = OverrideState::NoOverride;
 uint8_t currentStage = 0;
 
 Stage SCHEDULE[SCHEDULE_LENGTH] = {
-  // Wait for max <time> or until surface signal
+  // Pump immediately in case we just rebooted at the bottom of the pool
+  {StageType::Pump,             PUMP_MAX    },
+
+ // Wait for max <time> or until surface signal
   {StageType::WaitDeploying,    RELEASE_MAX },
 
  // Profile 1


### PR DESCRIPTION
# Pull Request

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Modify the float to pump on boot (in case we reboot at the pool bottom) and start transmitting immediately after flushing the syringe to surface.